### PR TITLE
add description for potsdam tutorial

### DIFF
--- a/_data/categories.yml
+++ b/_data/categories.yml
@@ -13,7 +13,7 @@ blocks:
     en: Blocks
     es: Bloques
   description:
-    de: Schreibe eigene Programme, indem du Blöcke zusammen steckst.    
+    de: Schreibe eigene Programme, indem du Blöcke zusammen steckst.
     en: Write your own programs by plugging building blocks together.
     es: Escribe tus propios programas juntando bloques.
 syntax:
@@ -31,4 +31,10 @@ python:
   description:
     de: Python is eine Allzweckprogramiersprache.
     en: Python is an all purpose programming language.
-    es: Python es un potente lenguaje de programación que se puede usar para muchas cosas 
+    es: Python es un potente lenguaje de programación que se puede usar para muchas cosas
+javascript:
+  name: JavaScript
+  url: https://www.javascript.com/
+  description:
+    de: JavaScript ist die Programmiersprache, in der Webseiten geschrieben werden.
+    en: JavaScript is the programming language for websites.

--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -169,10 +169,10 @@ jshero:
   - syntax
   - javascript
 
-opentechschool:
+opentechschool-javascript-beginners:
   title:
     en: Curriculum - JavaScript for absolute beginners
-    de: Kursmaterial - JavaScript für absolute Beginner
+    de: Kursmaterial - JavaScript für absolute Anfänger
   description:
     en: The goal of this workshop is to learn enough JavaScript to be dangerous, and to get a good feel for the natural habitat (web, browser, HTML) of JavaScript programs.
     de: Unser Ziel für diesen Workshop ist es, genug JavaScript zu lernen um gefährlich zu sein und nebenbei ein Gefühl für JavaScripts natürlichen Lebensraum (Web, Browser, HTML) zu bekommen.
@@ -180,11 +180,11 @@ opentechschool:
     en: https://opentechschool.github.io/js-beginners-1/
     de: https://opentechschool.github.io/js-beginners-1/index_de.html
   links:
-  - name: Online
-    url: https://opentechschool.github.io/js-beginners-1/
   - name: Offline
     url: offline/js-beginners/index.html
     offline: true
+  - name: Online
+    url: https://opentechschool.github.io/js-beginners-1/
   categories:
   - syntax
   - javascript

--- a/potsdam.html
+++ b/potsdam.html
@@ -18,3 +18,17 @@ structure:
   - codecombat
   - waterloo
 ---
+
+<p>
+  Mentoren lesen bitte den <a href="http://opentechschool.github.io/slides/presentations/coaching/">Guide der OpenTechSchool</a>.
+  Unten ist eine Liste an Tutorial, an die man aber nicht gebunden ist.
+</p>
+<p>
+  <a href="http://jugendprogrammiert.weebly.com/programmieren">Andere Programmiersprachen</a>
+  ohne Tutorials verlangen mehr Hilfe von Mentoren oder schon Vorkenntnisse im Programmieren.
+  <a href="http://jugendprogrammiert.weebly.com/organisationen/category/freie-materialien">Weitere Materialien</a>
+  können durschstöbert werden, um mehr Tutorials zu finden.
+  Wer das Coder Dojo mitgestalten möchte, kann das gerne tun und
+  <a href="https://groups.google.com/forum/#!forum/coderdojopotsdam-discuss">mitdiskutieren</a> und auch
+  <a href="https://github.com/CoderDojoPotsdam/intro/blob/master/potsdam.html">diese Seite editieren</a>.
+</p>

--- a/potsdam.html
+++ b/potsdam.html
@@ -17,6 +17,11 @@ structure:
   structure:
   - codecombat
   - waterloo
+  - id: javascript
+    structure:
+    - jshero
+    - opentechschool-javascript-beginners
+    - khanacademy
 ---
 
 <p>


### PR DESCRIPTION
Issue for this pull request:   <!-- paste a link or write #1 for issue number 1      ⬇
                                    https://github.com/CoderDojoPotsdam/intro/issues/1
                                    #2 for issue number 2, ... -->

**Problem to solve:**

make the site standalone and decouple it from zen to foster contribution

**Solution chosen:**

Add description from zen https://coderdojopotsdam/github.io