### PR TITLE
fix #71

### DIFF
--- a/servers.txt
+++ b/servers.txt
@@ -1,2 +1,3 @@
 http://localhost:25444/announce
+http://intro.quelltext.eu/announce
 https://intro.quelltext.eu/announce


### PR DESCRIPTION
add http server link

Issue for this pull request: #71  <!-- paste a link or write #1 for issue number 1      ⬇
                                    https://github.com/CoderDojoPotsdam/intro/issues/1
                                    #2 for issue number 2, ... -->

**Problem to solve:**
offline servers use http. They can access http. But in case of a certificate issue with my server, they can not because https is the only option.

**Solution chosen:**

add http option