### PR TITLE
add more links to scratch

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -59,6 +59,18 @@ scratch:
   links:
   - name: Invent with Scratch
     url: https://inventwithscratch.com/book/
+  - name:
+      en: Online
+      de: Online
+    url: https://scratch.mit.edu/
+  - name:
+      en: Download
+      de: Download
+    url: https://scratch.mit.edu/download/
+  - name:
+      en: Version 1.4
+      de: Version 1.4
+    url: https://scratch.mit.edu/scratch_1.4/
   categories:
   - blocks
 


### PR DESCRIPTION
Issue for this pull request: none  <!-- paste a link or write #1 for issue number 1      ⬇
                                    https://github.com/CoderDojoPotsdam/intro/issues/1
                                    #2 for issue number 2, ... -->

**Problem to solve:**
Scratch just had the title and a book.

**Solution chosen:**
I added download links and Version 1.4
