### PR TITLE
add offline server list to the menu

### DIFF
--- a/_layouts/overview.html
+++ b/_layouts/overview.html
@@ -26,12 +26,12 @@
           <a href="{{ page.homepage }}" class="brand-logo">
             <img class="page-logo" src="{{ page.image | escape }}"/>{{ page.title | escape }}
           </a>
-          <select class="invisible" id="offline-servers" onchange="switchOfflineServer(this)"></select>
           <ul id="nav-mobile" class="right hide-on-med-and-down">
             {%- for language in site.data.languages %}
               <li><a href="#section-{{ language.id | escape }}">{{ language.name | escape }}</a></li>
             {%- endfor %}
             <li><a href="index.html">Homepage</a></li>
+            <li><select class="invisible browser-default" id="offline-servers" onchange="switchOfflineServer(this)"></select></li>
           </ul>
         </div>
       </nav>

--- a/css/overview.css
+++ b/css/overview.css
@@ -20,7 +20,11 @@ footer img {
 /*******************************************************
  * offline servers
  */
+#offline-servers {
+  display: inline-block;
+  background-color: transparent;
+}
 
 #offline-servers.invisible {
    display: none;
- }
+}


### PR DESCRIPTION
Issue for this pull request:   <!-- paste a link or write #1 for issue number 1      ⬇
                                    https://github.com/CoderDojoPotsdam/intro/issues/1
                                    #2 for issue number 2, ... -->

**Problem to solve:**
The offline server list was not shown

**Solution chosen:**
- Add the offline server list to the menu
- ignore the materialize styling for it

To test this, run an offline server.