### PR TITLE
change link to new location of tryruby

### DIFF
--- a/_data/tutorials.yml
+++ b/_data/tutorials.yml
@@ -423,7 +423,7 @@ go-tour:
 try-ruby:
   title: Try Ruby
   description: Got 15 minutes? Give Ruby a shot right now!
-  url: http://tryruby.org
+  url: https://ruby.github.io/TryRuby/
   categories:
   - ruby
   - syntax


### PR DESCRIPTION


Issue for this pull request: fixes #106  <!-- paste a link or write #1 for issue number 1      ⬇
                                    https://github.com/CoderDojoPotsdam/intro/issues/1
                                    #2 for issue number 2, ... -->

**Problem to solve:**
tryruby does not work

**Solution chosen:**
correct the link
