### PR TITLE
fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
+  - 2.3
 env:
   global:
     - OFFLINE_BUILD_FOLDER=intro


### PR DESCRIPTION

**Problem to solve:**

https://travis-ci.org/CoderDojoPotsdam/intro/jobs/495502905#L473
bundler requires Ruby version >= 2.3.0. The current ruby version is 2.1.0.
the build fails

**Solution chosen:**

increase ruby version number